### PR TITLE
Add plutil to optimize xml files (fixes a notice in the CI)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         if: ${{ inputs.create_release }}
         run: |
           sudo apt update
-          sudo apt install -y build-essential checkinstall git autoconf automake libtool-bin rsync llvm xmlstarlet
+          sudo apt install -y build-essential checkinstall git autoconf automake libtool-bin rsync llvm xmlstarlet plutil
           curl -L https://github.com/libimobiledevice/libplist/releases/download/2.4.0/libplist-2.4.0.tar.bz2 | bzip2 -d | tar -x
           cd libplist*
           ./configure


### PR DESCRIPTION
Fixes the below notices:
![image](https://github.com/user-attachments/assets/704b120a-0a4e-47c9-9b43-1174142d3b81)
Minor thingie, but also quickly resolved.

> Making stage for tweak RedditFilter…
==> Notice: Neither plutil, ply, or libplist-utils are installed, so XML plist files were not optimized. dm.pl: building package `com.level3tjg.redditfilter:iphoneos-arm' in `./packages/com.level3tjg.redditfilter_1.1.6_iphoneos-arm.deb'

Adding this package fixes the notice. I notice the CI is a second or 2 slower but that probably varies between runs.